### PR TITLE
Update picprog.ino

### DIFF
--- a/picprog.ino
+++ b/picprog.ino
@@ -110,7 +110,7 @@ void setup() {
 			Serial.println("STC-1000 detected");
 			lvp_entry();
 			bulk_erase_device();
-#ifdef AUTOMATIC_UPLOAD_FAHRENHEIT
+#if AUTOMATIC_UPLOAD_FAHRENHEIT
 			upload_hex_from_progmem(hex_fahrenheit);
 			upload_hex_from_progmem(hex_eeprom_fahrenheit);
 			write_magic(STC1000P_MAGIC_F);


### PR DESCRIPTION
AUTOMATIC_UPLOAD_FAHRENHEIT is always defined so this would always be true and CELCIUS would never be used