### PR TITLE
Fixing 404 link in master README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The goal of this project is twofold
 The first goal is achieved by using an Arduino (UNO and Pro Mini 5v verified to work) with a sketch to act as a programmer, and the second by using the SDCC compiler and GPUTILS. 
 
 Download by visiting the [releases page](https://github.com/matsstaff/stc1000p/releases)
-and start by reading [the user manual](/usermanual/usermanual.md)
+and start by reading [the user manual](/usermanual/README.md)
 
 Features
 --------


### PR DESCRIPTION
Hi Mats,

Thanks for this great project.  Since you changed the usermanual name this fixes a 404 on the master README to point to the correct usermanual/README

Cheers!
-Kevin