### PR TITLE
shave 8 instructions out of read_ad

### DIFF
--- a/src/page0.c
+++ b/src/page0.c
@@ -866,15 +866,20 @@ static void interrupt_service_routine(void) __interrupt 0 {
 #endif
 
 static unsigned int read_ad(unsigned int adfilter){
-	unsigned char adfilter_l = adfilter >> (8 + FILTER_SHIFT -1);
-	if(adfilter_l == 31 || adfilter_l==0) {
+	word_lo_hi_t temp;
+	unsigned char adfilter_h = adfilter >> 8;
+	if(adfilter_h >= 248 || adfilter_h <= 8) {
 		state_flags.ad_badrange = 1;
 	}
 
 	ADGO = 1;
 	while(ADGO);
 	ADON = 0;
-	return ((adfilter - (adfilter >> FILTER_SHIFT)) + ((ADRESH << 8) | ADRESL));
+	temp.hi= ADRESH;
+	temp.lo = ADRESL;
+	adfilter -= (adfilter >> FILTER_SHIFT);
+	adfilter += temp.word;
+	return adfilter;
 }
 
 static int ad_to_temp(unsigned int adfilter){

--- a/src/stc1000p.h
+++ b/src/stc1000p.h
@@ -70,6 +70,16 @@
 #define	MENU_IDLE				TMR1GE
 #define	SENSOR_SELECT			TX9
 
+// a fun optimization which lets us more quickly assemble a 16-bit word out of two bytes
+// note: instances receives their own allocation in the UDL_page0_0 register page when used privately in a function
+typedef union {
+	unsigned int word;
+	struct {
+		unsigned char lo;
+		unsigned char hi;
+	};
+} word_lo_hi_t;
+
 #if defined(OVBSC)
 	#define RUN_PRG				C1POL
 	#define ALARM				C2POL


### PR DESCRIPTION
here's an amusing one.
I went in to optimize the adfilter range checking again, and noticed that if you make a union of an int and 2 chars, you can more efficiently access the hi & lo bytes when assembling the 16-bit value.
this saves 8 instructions.
might be able to repeat this pattern elsewhere where you do something like:
int blah = (hi << 8) | lo;
the only odd part I noticed is that the allocation for a function-local version of this union ends up getting it's own slot in the UDL_page0_0 compiler-defined variables section.  I think that's okay though.
I toyed with the idea of making an array of 2 of this union globally, and having read_ad() just take a 0/1 arg for which one to update, but this ended up leading to larger code due to the indirect addressing into the array.  meh.

I should probably have merged newpb2 into optimization and then made the optimization on that branch, but I guess I'm working slightly out of order here optimizing your new code :)

I'll go back to optimizing the older code that is unlikely to change with your new effort.  BTW, I think we've now optimized over 11% back!

(hopefully I didn't get lo & hi reversed in the union)