### PR TITLE
STC-1000+ Brew

### DIFF
--- a/com.ino
+++ b/com.ino
@@ -235,7 +235,7 @@ void print_config_value(unsigned char address, int value){
 			} else {
 				Serial.println("th");
 			}
-		} else if(address <= EEADR_SET_MENU_ITEM(setpoint)){
+		} else if(address <= EEADR_SET_MENU_ITEM(setpoint_alarm)){
 			print_temperature(value);
 		} else {
 			Serial.println(value);
@@ -339,7 +339,7 @@ unsigned char parse_config_value(const char *cmd, int address, bool pretty, int 
 			if((address & 1) == 0){
 				return parse_temperature(cmd, data);
 			}
-		} else if(address <= EEADR_SET_MENU_ITEM(setpoint)){
+		} else if(address <= EEADR_SET_MENU_ITEM(setpoint_alarm)){
 			return parse_temperature(cmd, data);
 		} else if(address == EEADR_SET_MENU_ITEM(run_mode)) {
 			if(!strncmp(cmd, "Pr", 2)){

--- a/com.ino
+++ b/com.ino
@@ -146,18 +146,15 @@ bool read_cooling(int *cooling){
 
 /* From here example implementation begins, this can be exchanged for your specific needs */
 enum set_menu_enum {
-	hysteresis,			// hy (hysteresis)
-	hysteresis2,			// hy2 (hysteresis probe 2)
-	temperature_correction,		// tc (temperature correction)
-	temperature_correction2,	// tc2 (temperature correction probe 2)
-	setpoint_alarm,			// SA (setpoint alarm)
 	setpoint,			// SP (setpoint)
+	hysteresis,			// hy (hysteresis)
+	temperature_correction,		// tc (temperature correction)
+	setpoint_alarm,			// SA (setpoint alarm)
 	step,				// St (current running profile step)	
 	duration,			// dh (current running profile step duration in hours)
 	cooling_delay,			// cd (cooling delay minutes)
 	heating_delay,			// hd (heating delay minutes)
 	ramping,			// rP (0=disable, 1=enable ramping)
-	probe2,				// Pb (0=disable, 1=enable probe2 for regulation)
 	run_mode			// rn (0-5 run profile, 6=thermostat)
 };
 
@@ -169,18 +166,15 @@ enum set_menu_enum {
 #define EEADR_POWER_ON				127
 
 const char menu_opt[][4] = {
-	"hy",
-	"hy2",
-	"tc",
-	"tc2",
-	"SA",
 	"SP",
+	"hy",
+	"tc",
+	"SA",
 	"St",
 	"dh",
 	"cd",
 	"hd",
 	"rP",
-	"Pb2",
 	"rn"
 };
 


### PR DESCRIPTION
Hello,
I have found the STC-1000+ Brew to be very helpful in my brewing setup (Bielmeier). I think this software makes brewday more relaxing and helps me brew with better precision and repeatability. It's GREAT! 

I have a few suggestions that I think will contribute to ease of use of the software.
They are all related to what's on display when running the program. 
When first running program and waiting for St to be reached, a press on Up reveals Output Effect (in my case with one heating element: 100.
I think it would be more useful to present St temperature setpoint instead of output. By that I get a verification of what temperature the system is heading at, and can approximate what time is left until there.

When into the different Mashing steps, a press on the arrows displays actual mashing steps and setpoints. Would it be possible to display remaining time instead for example of the name of the step?
For example, a standard 65*C  and 60 min would then display 65 when pressing Up and remaining time when pressing DOWN.  By that you can figure out how long time is left until next mashing-step and until time to do lautering etc. 

The same goes for several other steps, where Output Effect is presented when pressing UP. 

Is it possible to implement these functions in a simple manner?

Thanks för your great work! 

Magnus Juvén
pilsnerbryggeriet.wordpress.com


